### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server implementation for Dart, providing task management, document handling, and workspace organization capabilities through MCP tools.
 
+<a href="https://glama.ai/mcp/servers/2pdqgspm4q">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/2pdqgspm4q/badge" alt="Dart Server MCP server" />
+</a>
+
 ## Prerequisites
 
 - Node.js 16.x or higher


### PR DESCRIPTION
This PR adds a badge for the [Dart MCP Server](https://glama.ai/mcp/servers/2pdqgspm4q) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/2pdqgspm4q">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/2pdqgspm4q/badge" alt="Dart Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.